### PR TITLE
Support for LocalForward (ENV VARS NAME CHANGE!!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 Auto SSH RemoteTunnel
 =====================
-This container can be used for tunneling traffic from a remote endpoint onto
-containers, using the SSH protocol.
-This can be very useful if you docker-node or even swarm is located behind NAT.
+This image can be used for tunneling traffic from a remote endpoint onto
+containers, using the SSH protocol, which can be very useful if you docker-node
+or even swarm is located behind NAT. Also this image can be used for "proxying"
+from a stack to an external service, through SSH.
 
-Configuring sshd
+Configuring sshd _(for RemoteForward)_
 ================
 For the setup to work, the sshd running on the _remote_ server must be have the
 following enabled
@@ -30,16 +31,18 @@ Setting up Tunnels
 ==================
 Which ports should be tunneled is controlled by setting environment variables
 in the container.
-- `RT_TARGET` - The target/_remote endpoint_ on which to login.
+- `TARGET` - The target/_remote endpoint_ on which to login.
   Fx. `joe@server.mydomain.tld`
-- `RT_TARGET_PORT` - The port on which the *sshd* is listening on the target-host
-- `RT_TUNNEL_*` - All _tunnel-descriptions_ are converted into `-R` arguments on
-  the ssh connection. **(Note names of `RT_TUNNEL_*` variables MUST be unique, but
-  the suffix is not of importance)**
-
+- `TARGET_PORT` - The port on which the *sshd* is listening on the target-host
+- `R_TUNNEL_*` - All _remote-forward-descriptions_ are converted into `-R` arguments
+  on the ssh connection. **(Note names of `R_TUNNEL_*` variables MUST
+  be unique, but the suffix is not of importance)**
+- `L_TUNNEL_*` - All _local-forward-descriptions_ are converted into `-L` arguments
+  on the ssh connection. **(Note names of `L_TUNNEL_*` variables MUST bu unique,
+  but the suffix is not of importance)**
 - `KEY_FILE` - Can be used for overriding the name of the key to be generated or
   to force autossh to use a specific key.
-- `KEY_ALGO` - Can be used to override the algorithem used when generating a new
+- `KEY_ALGO` - Can be used to override the algorithm used when generating a new
   key, defaults to `ed25519`
 - `SSH_OPTS` - Can be used for passing arguments directly to the ssh-client such
   as `-v` for a bit of debugging.
@@ -50,8 +53,9 @@ A single volume is defined in the container `/root/.ssh` this volume will hold
 the generated pubic/private key-pair, as well as the `config` file that will
 hold some general configuration.
 It is also using this volume possible to move tunnel configuration away from
-environment variables and store it in the `config` file using `RemoteForward`.
+environment variables and store it in the `config` file using `RemoteForward` and
+`LocalForward`
 
 Docker-compose
 ==============
-A small example of how this could be used id found here [here](docker-compose.yml)
+A small example of how this could be used id found here [here](https://github.com/thorsager/auto-ssh-rtunnel/blob/master/docker-compose.yml)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,25 @@ services:
   web3:
     image: hashicorp/http-echo
     command: -text="hello world, from web 3"
+
   rtunnel:
     build: .
     volumes:
       - rtunnel:/root/.ssh
     environment:
-      - RT_TARGET=user@myhost
-      - RT_TARGET_PORT=22
-      - RT_TUNNEL_0=3000:web:5678
-      - RT_TUNNEL_1=3001:web2:5678
-      - RT_TUNNEL_2=3002:web3:5678
-      # - SSH_OPTS=-v
+      - TARGET=mit@ljump-1
+      - TARGET_PORT=22
+      - R_TUNNEL_0=3000:web:5678
+      - R_TUNNEL_1=3001:web2:5678
+      - R_TUNNEL_2=3002:web3:5678
+
+  ltunnel:
+      - TARGET=user@my-jump-host
+      - TARGET_PORT=22
+      - L_TUNNEL_0=3306:85.218.128.197:3306
+      - SSH_OPTS=-v
+    ports:
+      - 3306:3306
+
 volumes:
   rtunnel:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,23 +31,27 @@ echo "==== Public key ===="
 cat ${KEY_FILE}.pub
 echo "===================="
 
-if [[ -z ${RT_TARGET} ]]; then
-  echo "NO Target host found! please set RT_TARGET"
+if [[ -z ${TARGET} ]]; then
+  echo "NO Target host found! please set TARGET"
   exit 1;
 fi
 
-if [[ -z ${RT_TARGET_PORT} ]]; then
-  echo "NO Target port found! please set RT_TARGET_PORT"
+if [[ -z ${TARGET_PORT} ]]; then
+  echo "NO Target port found! please set TARGET_PORT"
   exit 1;
 fi
 
-for TUNNEL_CFG in $(env | grep RT_TUNNEL_); do
+for TUNNEL_CFG in $(env | grep R_TUNNEL_); do
   TUNNEL_OPTS="${TUNNEL_OPTS} -R ${TUNNEL_CFG#*=}"
 done
 
+for TUNNEL_CFG in $(env | grep L_TUNNEL_); do
+  TUNNEL_OPTS="${TUNNEL_OPTS} -L ${HOST_IP}:${TUNNEL_CFG#*=}"
+done
+
 echo "****"
-echo "**** ${TUNNEL_OPTS}"
+echo "**** autossh -N ${TUNNEL_OPTS} ${TARGET} -p ${TARGET_PORT} -i ${KEY_FILE} ${SSH_OPTS}"
 echo "****"
 
-echo autossh -N ${TUNNEL_OPTS} ${RT_TARGET} -p ${RT_TARGET_PORT} -i ${KEY_FILE} ${SSH_OPTS}
-exec autossh -N ${TUNNEL_OPTS} ${RT_TARGET} -p ${RT_TARGET_PORT} -i ${KEY_FILE} ${SSH_OPTS}
+echo autossh -N ${TUNNEL_OPTS} ${TARGET} -p ${TARGET_PORT} -i ${KEY_FILE} ${SSH_OPTS}
+exec autossh -N ${TUNNEL_OPTS} ${TARGET} -p ${TARGET_PORT} -i ${KEY_FILE} ${SSH_OPTS}


### PR DESCRIPTION
This commit adds support for setting up LocalForward tunnes as well
ass RemoteForward tunnels.
Multiple tunnels of both types can be set up in a single container
if the are terminated on the same target host.

Please Note that `RT_TARET` has changed name to `TARGET`,
`RT_TARGET_PORT` has changed name to `TARGET_PORT`, `TR_TUNNEL_*` has
changed name to `R_TUNNEL_*` and the new `L_TUNNEL_*` has been added.